### PR TITLE
Update popup.html and add event listener to open new page upon install

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hide Amazon Cart",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Hide the Amazon cart sidebar while browsing on Amazon.",
   "permissions": ["scripting"],
   "icons": {

--- a/popup.html
+++ b/popup.html
@@ -2,7 +2,7 @@
   <body>
     <h2>Hide Amazon Cart</h2>
     <p>
-      version: 0.0.3 |
+      version: 0.0.4 |
       <a
         href="https://github.com/garnetred/hide-amazon-cart"
         style="color: navy"

--- a/popup.html
+++ b/popup.html
@@ -6,6 +6,7 @@
       <a
         href="https://github.com/garnetred/hide-amazon-cart"
         style="color: navy"
+        target="_blank"
         >github</a
       >
     </p>

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -1,3 +1,12 @@
+chrome.runtime.onInstalled.addListener(({ reason }) => {
+  if (reason === 'install') {
+    chrome.tabs.create({
+      url: 'https://decemberdevelopment.com/hide-amazon-cart',
+      active: true,
+    });
+  }
+});
+
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
   const tabUrl = tab.url ?? tab.pendingUrl;
   if (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Overview
I created a basic faq page for users on my website. This change mostly redirects users to that page upon install. 

<!--- Describe your changes in detail -->

## Background
I decided to make this change to address any questions users might have and direct them to the Github page, which lists all of the currently supported Amazon domains. This information isn't allowed on the extension page due to Chrome Web Store regulations. 

The other change I made was updating the link to the github repo in popup.html to open in a new tab. Because I didn't have `target="_blank"` originally it wasn't opening at all. 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing
You can test by cloning down this branch, loading the unpacked extension in the "manage extensions"  (chrome://extensions) page while in developer mode. Once the extension is loaded, it should immediately navigate to [this faq page](https://www.decemberdevelopment.com/hide-amazon-cart). 

You can also add an item to your cart on Amazon and test that the existing functionality is still working. 
<!--- Please describe in detail how to test these changes. -->

## Screenshot(s):

<!-- Please include any screenshots if applicable. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have self-reviewed my code and added comments where relevant.
- [ ] I have updated any relevant documentation.
